### PR TITLE
chore: add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ venv
 .idea
 **/__pycache__
 .coverage
+
+.python-version

--- a/README.md
+++ b/README.md
@@ -12,6 +12,38 @@ Python 3.10
   - Server members intent
   - Message content intent
 
+### Python
+
+#### Installing Python 3.10 with pyenv
+
+One way to manage your local Python version is using [pyenv](https://github.com/pyenv/pyenv). Please follow the installation guide for it.
+
+```
+# Install Python 3.10.x
+pyenv install 3.10.19
+
+# Set Python 3.10 for this project (this creates a .python-version file in the project directory)
+pyenv local 3.10.19
+
+# Check Python version
+python --version
+```
+
+#### Installing dependencies in a virtual environment
+
+It is recommended to use `venv` for creating a virtual environment in the project directory.
+
+```
+# Create the virtual env
+python -m venv venv
+
+# Activate the virtual env
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
 ## Usage
 1. Fill the sample config with your bot token and guild id (guild id is an integer remove the quotes)
 2. Rename it to config.json


### PR DESCRIPTION
Adding `.python-version` to `.gitignore` to prevent it from being tracked in version control. It's used for `pyenv`, which I use for controlling the Python version in my environment.

I'm also adding some new sections to README for Python setup.