### PR TITLE
refactor: convert reddit client to be instance-based instead of a singleton

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,7 @@ from util import (
 )
 
 from reddit import (
-    extract_reddit_post_content_from_str,
+    RedditClient,
     is_str_with_reddit_url,
 )
 
@@ -38,6 +38,8 @@ discord_client.tree = app_commands.CommandTree(discord_client)
 
 gpt_conversation_client = GPTClient(base_model=config.get_gpt_model_base())
 gpt_code_client = GPTClient(base_model=config.get_gpt_model_code())
+
+reddit_client = RedditClient()
 
 
 @discord_client.event
@@ -65,7 +67,7 @@ async def on_message(message: Message):
 
     if config.is_reddit_user(message.author.id) and is_str_with_reddit_url(message.content):
         try:
-            formatted_message = await extract_reddit_post_content_from_str(message.content)
+            formatted_message = await reddit_client.extract_reddit_post_content_from_str(message.content)
             await message.channel.send(formatted_message, reference=message)
         except Exception as e:
             print(f"Error processing Reddit URL: {e}")

--- a/src/reddit.py
+++ b/src/reddit.py
@@ -17,14 +17,6 @@ class RedditPostInfo(BaseModel):
 
 
 class RedditClient:
-    _instance = None
-    _initialized = False
-
-    def __new__(cls):
-        if cls._instance is None:
-            cls._instance = super(RedditClient, cls).__new__(cls)
-        return cls._instance
-
     def __init__(self):
         if not self._initialized:
             reddit_client_id = os.getenv("REDDIT_CLIENT_ID")
@@ -40,9 +32,8 @@ class RedditClient:
 
             self.headers = {**self.headers, **{"Authorization": f"bearer {TOKEN}"}}
             self.client = httpx.AsyncClient(follow_redirects=True, headers=self.headers, timeout=10.0)
-            RedditClient._initialized = True
 
-    async def get(self, url: str) -> httpx.Response:
+    async def __get(self, url: str) -> httpx.Response:
         # replace www with oauth
         url = url.replace("www.", "")
         url = url.replace("reddit.com", "oauth.reddit.com")
@@ -50,51 +41,60 @@ class RedditClient:
         return await self.client.get(url)
 
     @classmethod
-    async def close(cls):
+    async def close(self):
         """Close the HTTP client when done."""
-        if hasattr(cls._instance, "client"):
-            await cls._instance.client.aclose()
-        cls._instance = None
-        cls._initialized = False
+        if self.client is not None:
+            await self.client.aclose()
+            self.client = None
+
+    async def fetch_reddit_post_info(self, url: str) -> Optional[RedditPostInfo]:
+        """
+        Fetches Reddit post information from a Reddit URL.
+        Returns a dictionary with title, content, author, and subreddit information.
+        """
+        # Handle shared links (/s/) by following redirects to get the actual post URL
+        if "/s/" in url:
+            response = await self.__get(url)
+            url = str(response.url)
+
+        # Remove query parameters and add .json suffix
+        clean_url = url.split("?")[0]
+        json_url = clean_url.rstrip("/") + ".json"
+
+        # Fetch post data from Reddit's JSON API
+        response = await self.__get(json_url)
+        response.raise_for_status()
+        data = response.json()
+
+        # Extract post data from Reddit API response structure
+        if data:
+            post_data = data[0]["data"]["children"][0]["data"]
+
+            return RedditPostInfo(
+                title=post_data.get("title", "No title"),
+                content=post_data.get("selftext", "") or post_data.get("url", ""),
+                author=post_data.get("author", "Unknown"),
+                subreddit=post_data.get("subreddit", "Unknown"),
+            )
+        else:
+            return None
+
+    async def extract_reddit_post_content_from_str(self, str: str) -> str:
+        """
+        Extracts and returns the content from Reddit post information.
+        """
+        match = search(REDDIT_POST_URL_REGEX, str)
+        if match:
+            post_url = match.group(0)
+            post_info = await self.fetch_reddit_post_info(post_url)
+            formatted_message = format_reddit_post_info(post_info)
+            return formatted_message
+
+        raise ValueError("No Reddit URL found in the provided string")
 
 
 def is_str_with_reddit_url(str: str) -> bool:
     return search(REDDIT_POST_URL_REGEX, str) is not None
-
-
-async def fetch_reddit_post_info(url: str) -> Optional[RedditPostInfo]:
-    """
-    Fetches Reddit post information from a Reddit URL.
-    Returns a dictionary with title, content, author, and subreddit information.
-    """
-    reddit_client = RedditClient()
-
-    # Handle shared links (/s/) by following redirects to get the actual post URL
-    if "/s/" in url:
-        response = await reddit_client.get(url)
-        url = str(response.url)
-
-    # Remove query parameters and add .json suffix
-    clean_url = url.split("?")[0]
-    json_url = clean_url.rstrip("/") + ".json"
-
-    # Fetch post data from Reddit's JSON API
-    response = await reddit_client.get(json_url)
-    response.raise_for_status()
-    data = response.json()
-
-    # Extract post data from Reddit API response structure
-    if data:
-        post_data = data[0]["data"]["children"][0]["data"]
-
-        return RedditPostInfo(
-            title=post_data.get("title", "No title"),
-            content=post_data.get("selftext", "") or post_data.get("url", ""),
-            author=post_data.get("author", "Unknown"),
-            subreddit=post_data.get("subreddit", "Unknown"),
-        )
-    else:
-        return None
 
 
 def format_reddit_post_info(post_info: RedditPostInfo) -> str:
@@ -126,17 +126,3 @@ def format_reddit_post_info(post_info: RedditPostInfo) -> str:
         message += f"\n{content}\n"
 
     return message
-
-
-async def extract_reddit_post_content_from_str(str: str) -> str:
-    """
-    Extracts and returns the content from Reddit post information.
-    """
-    match = search(REDDIT_POST_URL_REGEX, str)
-    if match:
-        post_url = match.group(0)
-        post_info = await fetch_reddit_post_info(post_url)
-        formatted_message = format_reddit_post_info(post_info)
-        return formatted_message
-
-    raise ValueError("No Reddit URL found in the provided string")

--- a/tests/test_reddit.py
+++ b/tests/test_reddit.py
@@ -1,7 +1,6 @@
 from src.reddit import (
     RedditPostInfo,
-    extract_reddit_post_content_from_str,
-    fetch_reddit_post_info,
+    RedditClient,
     format_reddit_post_info,
     is_str_with_reddit_url,
 )
@@ -42,71 +41,64 @@ class TestFetchRedditPostInfo:
     @pytest.mark.asyncio
     async def test_fetches_post_info_successfully(self):
         """Test that valid Reddit post URLs return correct post info."""
-        with patch("src.reddit.RedditClient") as mock_client:
-            # Mock the JSON response for the actual post
-            mock_response = Mock()
-            mock_response.json.return_value = self.mock_json_response_value
-            mock_response.raise_for_status.return_value = None
+        # Mock the JSON response for the actual post
+        mock_response = Mock()
+        mock_response.json.return_value = self.mock_json_response_value
+        mock_response.raise_for_status.return_value = None
 
-            # Set up the mock RedditClient instance
-            mock_client_instance = AsyncMock()
-            mock_client_instance.get.return_value = mock_response
-            mock_client_instance.__aenter__.return_value = mock_client_instance
-            mock_client_instance.__aexit__.return_value = None
+        with patch.object(RedditClient, "__init__", lambda self: None):
+            client = RedditClient()
 
-            mock_client.return_value = mock_client_instance
+            with patch.object(client, "_RedditClient__get", new_callable=AsyncMock) as mock_get:
+                mock_get.return_value = mock_response
 
-            result = await fetch_reddit_post_info("https://reddit.com/r/test/comments/123/test/")
+                result = await client.fetch_reddit_post_info("https://reddit.com/r/test/comments/123/test/")
 
-            assert result is not None
-            assert result.title == "Test Post"
-            assert result.content == "This is a test post"
-            assert result.author == "testuser"
-            assert result.subreddit == "testsub"
+                assert result is not None
+                assert result.title == "Test Post"
+                assert result.content == "This is a test post"
+                assert result.author == "testuser"
+                assert result.subreddit == "testsub"
 
-            # Verify that get was called once with the JSON URL
-            mock_client_instance.get.assert_called_once_with("https://reddit.com/r/test/comments/123/test.json")
+                # Verify that __get was called once with the JSON URL
+                mock_get.assert_called_once_with("https://reddit.com/r/test/comments/123/test.json")
 
     @pytest.mark.asyncio
     async def test_follows_redirects_for_shared_links(self):
         """Test that shared links (/s/) follow redirects correctly."""
-        with patch("src.reddit.RedditClient") as mock_client:
-            # Mock the redirect response for shared link
-            mock_redirect_response = Mock()
-            mock_redirect_response.url = "https://www.reddit.com/r/test/comments/abc123/test_post/"
+        # Mock the redirect response for shared link
+        mock_redirect_response = Mock()
+        mock_redirect_response.url = "https://www.reddit.com/r/test/comments/abc123/test_post/"
 
-            # Mock the JSON response for the actual post
-            mock_json_response = Mock()
-            mock_json_response.json.return_value = self.mock_json_response_value
-            mock_json_response.raise_for_status.return_value = None
+        # Mock the JSON response for the actual post
+        mock_json_response = Mock()
+        mock_json_response.json.return_value = self.mock_json_response_value
+        mock_json_response.raise_for_status.return_value = None
 
-            # Set up the mock RedditClient instance to return different responses
-            mock_client_instance = AsyncMock()
-            mock_client_instance.get.side_effect = [mock_redirect_response, mock_json_response]
-            mock_client_instance.__aenter__.return_value = mock_client_instance
-            mock_client_instance.__aexit__.return_value = None
+        with patch.object(RedditClient, "__init__", lambda self: None):
+            client = RedditClient()
 
-            mock_client.return_value = mock_client_instance
+            with patch.object(client, "_RedditClient__get", new_callable=AsyncMock) as mock_get:
+                mock_get.side_effect = [mock_redirect_response, mock_json_response]
 
-            # Test with a shared link URL
-            result = await fetch_reddit_post_info("https://reddit.com/r/test/s/abc123")
+                # Test with a shared link URL
+                result = await client.fetch_reddit_post_info("https://reddit.com/r/test/s/abc123")
 
-            # Verify the result
-            assert result is not None
-            assert result.title == "Test Post"
-            assert result.content == "This is a test post"
-            assert result.author == "testuser"
-            assert result.subreddit == "testsub"
+                # Verify the result
+                assert result is not None
+                assert result.title == "Test Post"
+                assert result.content == "This is a test post"
+                assert result.author == "testuser"
+                assert result.subreddit == "testsub"
 
-            # Verify that get was called twice (once for redirect, once for JSON)
-            assert mock_client_instance.get.call_count == 2
-            # First call should be the shared link
-            assert mock_client_instance.get.call_args_list[0][0][0] == "https://reddit.com/r/test/s/abc123"
-            # Second call should be the JSON URL
-            assert (
-                mock_client_instance.get.call_args_list[1][0][0]
-                == "https://www.reddit.com/r/test/comments/abc123/test_post.json"
-            )
+                # Verify that __get was called twice (once for redirect, once for JSON)
+                assert mock_get.call_count == 2
+                # First call should be the shared link
+                assert mock_get.call_args_list[0][0][0] == "https://reddit.com/r/test/s/abc123"
+                # Second call should be the JSON URL
+                assert (
+                    mock_get.call_args_list[1][0][0] == "https://www.reddit.com/r/test/comments/abc123/test_post.json"
+                )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -128,45 +120,39 @@ class TestFetchRedditPostInfo:
     )
     async def test_strips_query_parameters(self, url, expected):
         """Test that URLs with query parameters are handled correctly."""
-        with patch("src.reddit.RedditClient") as mock_client:
-            # Mock the JSON response for the actual post
-            mock_response = Mock()
-            mock_response.json.return_value = self.mock_json_response_value
-            mock_response.raise_for_status.return_value = None
+        # Mock the JSON response for the actual post
+        mock_response = Mock()
+        mock_response.json.return_value = self.mock_json_response_value
+        mock_response.raise_for_status.return_value = None
 
-            # Set up the mock RedditClient instance
-            mock_client_instance = AsyncMock()
-            mock_client_instance.get.return_value = mock_response
-            mock_client_instance.__aenter__.return_value = mock_client_instance
-            mock_client_instance.__aexit__.return_value = None
+        with patch.object(RedditClient, "__init__", lambda self: None):
+            client = RedditClient()
 
-            mock_client.return_value = mock_client_instance
+            with patch.object(client, "_RedditClient__get", new_callable=AsyncMock) as mock_get:
+                mock_get.return_value = mock_response
 
-            # Test with a URL that has query parameters
-            await fetch_reddit_post_info(url)
+                # Test with a URL that has query parameters
+                await client.fetch_reddit_post_info(url)
 
-            # Verify that get was called once for the JSON endpoint
-            mock_client_instance.get.assert_called_once_with(expected)
+                # Verify that __get was called once for the JSON endpoint
+                mock_get.assert_called_once_with(expected)
 
     @pytest.mark.asyncio
     async def test_returns_none_for_empty_response(self):
         """Test that no data in the JSON response returns None."""
-        with patch("src.reddit.RedditClient") as mock_client:
-            # Mock an empty JSON response
-            mock_response = Mock()
-            mock_response.json.return_value = []
-            mock_response.raise_for_status.return_value = None
+        # Mock an empty JSON response
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status.return_value = None
 
-            # Set up the mock RedditClient instance
-            mock_client_instance = AsyncMock()
-            mock_client_instance.get.return_value = mock_response
-            mock_client_instance.__aenter__.return_value = mock_client_instance
-            mock_client_instance.__aexit__.return_value = None
+        with patch.object(RedditClient, "__init__", lambda self: None):
+            client = RedditClient()
 
-            mock_client.return_value = mock_client_instance
+            with patch.object(client, "_RedditClient__get", new_callable=AsyncMock) as mock_get:
+                mock_get.return_value = mock_response
 
-            result = await fetch_reddit_post_info("https://reddit.com/r/test/comments/123/test/")
-            assert result is None
+                result = await client.fetch_reddit_post_info("https://reddit.com/r/test/comments/123/test/")
+                assert result is None
 
 
 class TestFormatRedditPostInfo:
@@ -216,27 +202,22 @@ class TestExtractRedditPostContentFromStr:
         }
         mock_json_response_value = [{"data": {"children": [{"data": mock_post_data}]}}]
 
-        with patch("src.reddit.RedditClient") as mock_client:
-            # Mock the JSON response for the actual post
-            mock_response = Mock()
-            mock_response.json.return_value = mock_json_response_value
-            mock_response.raise_for_status.return_value = None
+        # Mock the JSON response for the actual post
+        mock_response = Mock()
+        mock_response.json.return_value = mock_json_response_value
+        mock_response.raise_for_status.return_value = None
 
-            # Set up the mock RedditClient instance
-            mock_client_instance = AsyncMock()
-            mock_client_instance.get.return_value = mock_response
-            mock_client_instance.__aenter__.return_value = mock_client_instance
-            mock_client_instance.__aexit__.return_value = None
+        with patch.object(RedditClient, "__init__", lambda self: None):
+            client = RedditClient()
 
-            mock_client.return_value = mock_client_instance
+            with patch.object(client, "_RedditClient__get", new_callable=AsyncMock) as mock_get:
+                mock_get.return_value = mock_response
 
-            test_str = (
-                "Check out this Reddit post: https://www.reddit.com/r/testsubreddit/comments/abc123/test_post_title/"
-            )
-            result = await extract_reddit_post_content_from_str(test_str)
+                test_str = "Check out this Reddit post: https://www.reddit.com/r/testsubreddit/comments/abc123/test_post_title/"
+                result = await client.extract_reddit_post_content_from_str(test_str)
 
-            expected = "*Reddit Post from r/testsubreddit by u/testuser*\n\n**Test Post Title**\n\nThis is some test content for the post.\n"
-            assert result == expected
+                expected = "*Reddit Post from r/testsubreddit by u/testuser*\n\n**Test Post Title**\n\nThis is some test content for the post.\n"
+                assert result == expected
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -249,5 +230,8 @@ class TestExtractRedditPostContentFromStr:
     )
     async def test_raises_exception_for_str_without_reddit_url(self, test_str):
         """Test that passing a string without a Reddit URL raises a ValueError."""
-        with pytest.raises(ValueError):
-            await extract_reddit_post_content_from_str(test_str)
+        with patch.object(RedditClient, "__init__", lambda self: None):
+            client = RedditClient()
+
+            with pytest.raises(ValueError):
+                await client.extract_reddit_post_content_from_str(test_str)


### PR DESCRIPTION
Converting `RedditClient` from a singleton pattern to a simple instance-based class. My main aim is simplifying the class - in a later PR, I'll inject a settings class.

- Removed singleton implementation (`_instance`, `_initialized`, custom `__new__`)
- Converted standalone helper functions (`fetch_reddit_post_info`, `extract_reddit_post_content_from_str`) into instance methods
- Changed `RedditClient` to use simple instantiation: `reddit_client = RedditClient()`
- Updated `main.py `to instantiate and use the refactored client with the new method names
- Updated all tests to work with the instance-based pattern